### PR TITLE
Camel case to work with ethereum json rpc

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -389,7 +389,7 @@ class Client
     {
         return [
             'json' => [
-                'method' => strtolower($method),
+                'method' => $method,
                 'params' => (array) $params,
                 'id'     => $this->rpcId++,
             ],


### PR DESCRIPTION
I was testing this library to make it work with ethereum json rpc, interestingly it does work.
Ethereum json rpc methods has strict camel case names and doesn't work with all lower case method names.
e.g: 
=> "net_version" method works
bitcoind()->client('ethereum')->net_version()->get();

=> "web3_clientVersion" method doesn't work
bitcoind()->client('ethereum')->web3_clientVersion()->get();
Throws Exception: "The method web3_clientversion does not exist/is not available"

Ethereum JSON RPC methods ref: https://github.com/ethereum/wiki/wiki/JSON-RPC