### PR TITLE
client-specific setting to preserve case methods

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -389,7 +389,7 @@ class Client
     {
         return [
             'json' => [
-                'method' => strtolower($method),
+                'method' => isset($this->config['preserve_case']) ? $method : strtolower($method),
                 'params' => (array) $params,
                 'id'     => $this->rpcId++,
             ],


### PR DESCRIPTION
Following:
https://github.com/denpamusic/php-bitcoinrpc/pull/26

Add 'preserve_case' => true in client-specific settings
e.g:
'ethereum' => [
        'scheme'   => 'http',
        'host'     => 'localhost',
        'port'     => 8545,
        'ca'       => null,
        'preserve_case' => true,
],